### PR TITLE
Do not include junit as dependency

### DIFF
--- a/SDK/pom.xml
+++ b/SDK/pom.xml
@@ -42,6 +42,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
This library was including `junit` as a non-test dependency. This change removes `junit` as a non-test dependency by moving `junit` under the `test` scope.